### PR TITLE
gitsecure auto-remediation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 RUN apk add --update py-pip
 RUN pip install django==1.2 certifi==2019.3.9 chardet==3.0.4 idna==2.8
+#GITSECURE REMEDIATION 
+RUN  pip install Django>=1.8.15  
+
 
 WORKDIR /root/
 COPY --from=0 /go/src/github.com/alexellis/href-counter/app .


### PR DESCRIPTION
# GitSecure Vulnerablility Report
<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>Dockerfile <strong> Stage: </strong>stage-1
  </summary> 

:white_check_mark: OS Packages Safe 
:x: Pip Packages Safe 

# Vulnerability Analysis
 ## Vulnerable OS Packages 
No vulnerable os packages found
## Vulnerable Python Packages 
Total of 1 vulnerable pip packages found

Package <strong> Django  </strong> needs to  satisfy this version requirement  **>= 1.8.15** 
# Detailed Package Analysis 
Contains vulnerability, license and pedigree information for each package 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>
<p>
<details>
<summary> Package Name: chardet | Current Version: 3.0.4
  </summary> 

##### Python Vulnerabilities:

No Vulnerabilities Present in this Pip Package 
##### Compliance: 
*OSSC Compliant*: False 
*Last Reviewed License Version*: Not Available 
*Pedigree Reviewed*:   
*Last Reviewed Pedigree Version*: Not Available 
</details>
</p>

<p>
<details>
<summary> Package Name: idna | Current Version: 2.8
  </summary> 

##### Python Vulnerabilities:

No Vulnerabilities Present in this Pip Package 
##### Compliance: 
*OSSC Compliant*: True 
*Last Reviewed License Version*: Not Available 
*Pedigree Reviewed*:   
*Last Reviewed Pedigree Version*: Not Available 
</details>
</p>

<p>
<details>
<summary> Package Name: certifi | Current Version: 2019.3.9
  </summary> 

##### Python Vulnerabilities:

No Vulnerabilities Present in this Pip Package 
##### Compliance: 
*OSSC Compliant*: True 
*Last Reviewed License Version*: Not Available 
*Pedigree Reviewed*:   
*Last Reviewed Pedigree Version*: Not Available 
</details>
</p>

<p>
<details>
<summary> Package Name: Django | Current Version: 1.2  <strong>(VULNERABLE)</strong>
  </summary> 

##### Python Vulnerabilities:

*Recommended update* : >= 1.8.15 
<p>
1. Affected Versions  : <1.2.2 <details>
<summary> Description  </summary> 

Cross-site scripting (XSS) vulnerability in Django 1.2.x before 1.2.2 allows remote attackers to inject arbitrary web script or HTML via a csrfmiddlewaretoken (aka csrf_token) cookie. 
</details>
</p>

<p>
2. Affected Versions  : <1.2.7 <details>
<summary> Description  </summary> 

django.contrib.sessions in Django before 1.2.7 and 1.3.x before 1.3.1, when session data is stored in the cache, uses the root namespace for both session identifiers and application-data keys, which allows remote attackers to modify a session by triggering use of a key that is equal to that session's identifier. 
</details>
</p>

<p>
3. Affected Versions  : <1.2.7 <details>
<summary> Description  </summary> 

The verify_exists functionality in the URLField implementation in Django before 1.2.7 and 1.3.x before 1.3.1 relies on Python libraries that attempt access to an arbitrary URL with no timeout, which allows remote attackers to cause a denial of service (resource consumption) via a URL associated with (1) a slow response, (2) a completed TCP connection with no application data sent, or (3) a large amount of application data, a related issue to CVE-2011-1521. 
</details>
</p>

<p>
4. Affected Versions  : <1.2.7 <details>
<summary> Description  </summary> 

The verify_exists functionality in the URLField implementation in Django before 1.2.7 and 1.3.x before 1.3.1 originally tests a URL's validity through a HEAD request, but then uses a GET request for the new target URL in the case of a redirect, which might allow remote attackers to trigger arbitrary GET requests with an unintended source IP address via a crafted Location header. 
</details>
</p>

<p>
5. Affected Versions  : <1.2.7 <details>
<summary> Description  </summary> 

The CSRF protection mechanism in Django through 1.2.7 and 1.3.x through 1.3.1 does not properly handle web-server configurations supporting arbitrary HTTP Host headers, which allows remote attackers to trigger unauthenticated forged requests via vectors involving a DNS CNAME record and a web page containing JavaScript code. 
</details>
</p>

<p>
6. Affected Versions  : <1.3.2 <details>
<summary> Description  </summary> 

The (1) django.http.HttpResponseRedirect and (2) django.http.HttpResponsePermanentRedirect classes in Django before 1.3.2 and 1.4.x before 1.4.1 do not validate the scheme of a redirect target, which might allow remote attackers to conduct cross-site scripting (XSS) attacks via a data: URL. 
</details>
</p>

<p>
7. Affected Versions  : <1.3.2 <details>
<summary> Description  </summary> 

The django.forms.ImageField class in the form system in Django before 1.3.2 and 1.4.x before 1.4.1 completely decompresses image data during image validation, which allows remote attackers to cause a denial of service (memory consumption) by uploading an image file. 
</details>
</p>

<p>
8. Affected Versions  : <1.3.2 <details>
<summary> Description  </summary> 

The get_image_dimensions function in the image-handling functionality in Django before 1.3.2 and 1.4.x before 1.4.1 uses a constant chunk size in all attempts to determine dimensions, which allows remote attackers to cause a denial of service (process or thread consumption) via a large TIFF image. 
</details>
</p>

<p>
9. Affected Versions  : <1.3.4 <details>
<summary> Description  </summary> 

The django.http.HttpRequest.get_host function in Django 1.3.x before 1.3.4 and 1.4.x before 1.4.2 allows remote attackers to generate and display arbitrary URLs via crafted username and password Host header values. 
</details>
</p>

<p>
10. Affected Versions  : <1.4.18 <details>
<summary> Description  </summary> 

The django.util.http.is_safe_url function in Django before 1.4.18, 1.6.x before 1.6.10, and 1.7.x before 1.7.3 does not properly handle leading whitespaces, which allows remote attackers to conduct cross-site scripting (XSS) attacks via a crafted URL, related to redirect URLs, as demonstrated by a "\njavascript:" URL. 
</details>
</p>

<p>
11. Affected Versions  : <1.4.18 <details>
<summary> Description  </summary> 

The django.views.static.serve view in Django before 1.4.18, 1.6.x before 1.6.10, and 1.7.x before 1.7.3 reads files an entire line at a time, which allows remote attackers to cause a denial of service (memory consumption) via a long line in a file. 
</details>
</p>

<p>
12. Affected Versions  : <1.4.18 <details>
<summary> Description  </summary> 

Django before 1.4.18, 1.6.x before 1.6.10, and 1.7.x before 1.7.3 allows remote attackers to spoof WSGI headers by using an _ (underscore) character instead of a - (dash) character in an HTTP header, as demonstrated by an X-Auth_User header. 
</details>
</p>

<p>
13. Affected Versions  : <1.4.20 <details>
<summary> Description  </summary> 

The utils.http.is_safe_url function in Django before 1.4.20, 1.5.x, 1.6.x before 1.6.11, 1.7.x before 1.7.7, and 1.8.x before 1.8c1 does not properly validate URLs, which allows remote attackers to conduct cross-site scripting (XSS) attacks via a control character in a URL, as demonstrated by a \x08javascript: URL. 
</details>
</p>

<p>
14. Affected Versions  : <1.7.11 <details>
<summary> Description  </summary> 

The get_format function in utils/formats.py in Django before 1.7.x before 1.7.11, 1.8.x before 1.8.7, and 1.9.x before 1.9rc2 might allow remote attackers to obtain sensitive application secrets via a settings key in place of a date/time format setting, as demonstrated by SECRET_KEY. 
</details>
</p>

<p>
15. Affected Versions  : <1.7.6 <details>
<summary> Description  </summary> 

Cross-site scripting (XSS) vulnerability in the contents function in admin/helpers.py in Django before 1.7.6 and 1.8 before 1.8b2 allows remote attackers to inject arbitrary web script or HTML via a model attribute in ModelAdmin.readonly_fields, as demonstrated by a @property. 
</details>
</p>

<p>
16. Affected Versions  : <1.8.10 <details>
<summary> Description  </summary> 

The password hasher in contrib/auth/hashers.py in Django before 1.8.10 and 1.9.x before 1.9.3 allows remote attackers to enumerate users via a timing attack involving login requests. 
</details>
</p>

<p>
17. Affected Versions  : <1.8.10 <details>
<summary> Description  </summary> 

The utils.http.is_safe_url function in Django before 1.8.10 and 1.9.x before 1.9.3 allows remote attackers to redirect users to arbitrary web sites and conduct phishing attacks or possibly conduct cross-site scripting (XSS) attacks via a URL containing basic authentication, as demonstrated by http://mysite.example.com\@attacker.com. 
</details>
</p>

<p>
18. Affected Versions  : <1.8.15 <details>
<summary> Description  </summary> 

The cookie parsing code in Django before 1.8.15 and 1.9.x before 1.9.10, when used on a site with Google Analytics, allows remote attackers to bypass an intended CSRF protection mechanism by setting arbitrary cookies. 
</details>
</p>

<p>
19. Affected Versions  : >=1.2,<1.2.4 <details>
<summary> Description  </summary> 

The administrative interface in django.contrib.admin in Django before 1.1.3, 1.2.x before 1.2.4, and 1.3.x before 1.3 beta 1 does not properly restrict use of the query string to perform certain object filtering, which allows remote authenticated users to obtain sensitive information via a series of requests containing regular expressions, as demonstrated by a created_by__password__regex parameter. 
</details>
</p>

<p>
20. Affected Versions  : >=1.2,<1.2.4 <details>
<summary> Description  </summary> 

The password reset functionality in django.contrib.auth in Django before 1.1.3, 1.2.x before 1.2.4, and 1.3.x before 1.3 beta 1 does not validate the length of a string representing a base36 timestamp, which allows remote attackers to cause a denial of service (resource consumption) via a URL that specifies a large base36 integer. 
</details>
</p>

<p>
21. Affected Versions  : >=1.2,<1.2.5 <details>
<summary> Description  </summary> 

Django 1.1.x before 1.1.4 and 1.2.x before 1.2.5 does not properly validate HTTP requests that contain an X-Requested-With header, which makes it easier for remote attackers to conduct cross-site request forgery (CSRF) attacks via forged AJAX requests that leverage a "combination of browser plugins and redirects," a related issue to CVE-2011-0447. 
</details>
</p>

<p>
22. Affected Versions  : >=1.2,<1.2.5 <details>
<summary> Description  </summary> 

Directory traversal vulnerability in Django 1.1.x before 1.1.4 and 1.2.x before 1.2.5 on Windows might allow remote attackers to read or execute files via a / (slash) character in a key in a session cookie, related to session replays. 
</details>
</p>

##### Compliance: 
*OSSC Compliant*: False 
*Last Reviewed License Version*: Not Available 
*Pedigree Reviewed*:   
*Last Reviewed Pedigree Version*: Not Available 
</details>
</p>


</details>

</details>
</p>

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>Dockerfile <strong> Stage: </strong>stage-0
  </summary> 

:white_check_mark: OS Packages Safe 
:white_check_mark: Pip Packages Safe 

# Vulnerability Analysis
 ## Vulnerable OS Packages 
No vulnerable os packages found
## Vulnerable Python Packages 
No vulnerable pip packages found
# Detailed Package Analysis 
Contains vulnerability, license and pedigree information for each package 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

